### PR TITLE
Allow user connections patch to work bidirectionally

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -462,7 +462,12 @@ def update_user_connection(user_id, friend_id):
     status_input = request.json.get('status', '')
     u = connections_table.update()
     u = u.values({"status": status_input})
-    u = u.where(connections_table.c.user_id == user_id, connections_table.c.friend_id == friend_id)
+    if len(session.query(user_connection).filter_by(friend_id = friend_id, user_id = user_id).all()) == 1:
+        u = u.where(connections_table.c.user_id == user_id, connections_table.c.friend_id == friend_id)
+    elif len(session.query(user_connection).filter_by(friend_id = user_id, user_id = friend_id).all()) == 1:
+        u = u.where(connections_table.c.user_id == friend_id, connections_table.c.friend_id == user_id)
+    else:
+        return "no connection pending"
     engine.execute(u)
     return "connection updated"
 


### PR DESCRIPTION
# Description

User connection patch requests would fail if the user_if and Friend_id did not match the table.  Patch requests will now work if the user is listed as the friend in the database.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce. 

- [ ] Test A
- [ ] Test B


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (as needed)
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes